### PR TITLE
Add Azure Blob Storage service & upload endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 # ── Database (ASP.NET Core double-underscore format) ────────────────
 ConnectionStrings__DefaultConnection=
 
-# ── Azure Blob Storage (ASP.NET Core double-underscore format) ─────────
+# ── Azure Blob Storage (ASP.NET Core) ─────────
 AZURE_BLOB_CONNECTION_STRING=
 
 # ── Auth — Backend (ASP.NET Core double-underscore format) ──────────

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@
 # ── Database (ASP.NET Core double-underscore format) ────────────────
 ConnectionStrings__DefaultConnection=
 
+# ── Azure Blob Storage (ASP.NET Core double-underscore format) ─────────
+AZURE_BLOB_CONNECTION_STRING=
+
 # ── Auth — Backend (ASP.NET Core double-underscore format) ──────────
 Authentication__Google__ClientId=
 Authentication__Microsoft__ClientId=

--- a/Backend/Backend.csproj
+++ b/Backend/Backend.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />

--- a/Backend/Controllers/UsersController.cs
+++ b/Backend/Controllers/UsersController.cs
@@ -1,5 +1,6 @@
 using Backend.Data;
 using Backend.Models;
+using Backend.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -13,8 +14,13 @@ namespace Backend.Controllers;
 public class UsersController : ControllerBase
 {
     private readonly ApplicationDbContext _db;
+    private readonly IBlobStorageService _blobStorage;
 
-    public UsersController(ApplicationDbContext db) => _db = db;
+    public UsersController(ApplicationDbContext db, IBlobStorageService blobStorage)
+    {
+        _db = db;
+        _blobStorage = blobStorage;
+    }
 
     // Resolves email across Google and Microsoft token claim variations.
     // Microsoft Entra ID tokens often omit the "email" claim even when
@@ -122,6 +128,40 @@ public class UsersController : ControllerBase
         user.UpdatedAt       = DateTime.UtcNow;
         await _db.SaveChangesAsync();
         return Ok(user);
+    }
+
+    // POST api/users/me/profile-image — upload profile picture to Azure Blob Storage
+    [HttpPost("me/profile-image")]
+    [RequestSizeLimit(5 * 1024 * 1024)] // 5 MB limit
+    public async Task<IActionResult> UploadProfileImage(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+            return BadRequest(new { error = "No file provided." });
+
+        var allowedTypes = new[] { "image/jpeg", "image/png", "image/gif", "image/webp" };
+        if (!allowedTypes.Contains(file.ContentType.ToLower()))
+            return BadRequest(new { error = "Only JPEG, PNG, GIF, and WEBP images are allowed." });
+
+        var email = ResolveEmail();
+        if (string.IsNullOrWhiteSpace(email))
+            return Unauthorized();
+
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.Email == email);
+        if (user is null)
+            return NotFound(new { error = "User not found." });
+
+        // Delete old profile image from blob storage if one exists
+        if (!string.IsNullOrEmpty(user.ProfileImageUrl))
+            await _blobStorage.DeleteBlobAsync(user.ProfileImageUrl);
+
+        // Upload new image and save the returned URL
+        var imageUrl = await _blobStorage.UploadProfileImageAsync(file, user.UserId);
+
+        user.ProfileImageUrl = imageUrl;
+        user.UpdatedAt       = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+
+        return Ok(new { profileImageUrl = imageUrl });
     }
 
     // GET api/users — public

--- a/Backend/Controllers/UsersController.cs
+++ b/Backend/Controllers/UsersController.cs
@@ -133,13 +133,16 @@ public class UsersController : ControllerBase
     // POST api/users/me/profile-image — upload profile picture to Azure Blob Storage
     [HttpPost("me/profile-image")]
     [RequestSizeLimit(5 * 1024 * 1024)] // 5 MB limit
-    public async Task<IActionResult> UploadProfileImage(IFormFile file)
+    public async Task<IActionResult> UploadProfileImage([FromForm] IFormFile file)
     {
         if (file == null || file.Length == 0)
             return BadRequest(new { error = "No file provided." });
 
+        // Parse only the type/subtype portion before any parameters (e.g. "image/jpeg; charset=...")
+        // and compare with OrdinalIgnoreCase to avoid culture-sensitive ToLower()
+        var contentType = file.ContentType?.Split(';')[0].Trim() ?? "";
         var allowedTypes = new[] { "image/jpeg", "image/png", "image/gif", "image/webp" };
-        if (!allowedTypes.Contains(file.ContentType.ToLower()))
+        if (!allowedTypes.Contains(contentType, StringComparer.OrdinalIgnoreCase))
             return BadRequest(new { error = "Only JPEG, PNG, GIF, and WEBP images are allowed." });
 
         var email = ResolveEmail();
@@ -150,18 +153,32 @@ public class UsersController : ControllerBase
         if (user is null)
             return NotFound(new { error = "User not found." });
 
-        // Delete old profile image from blob storage if one exists
-        if (!string.IsNullOrEmpty(user.ProfileImageUrl))
-            await _blobStorage.DeleteBlobAsync(user.ProfileImageUrl);
+        var previousImageUrl = user.ProfileImageUrl;
 
-        // Upload new image and save the returned URL
-        var imageUrl = await _blobStorage.UploadProfileImageAsync(file, user.UserId);
+        // Upload new blob first, then update DB, then delete old blob last (best-effort).
+        // This ensures if upload or DB save fails, the user's existing image is not lost.
+        var newImageUrl = await _blobStorage.UploadProfileImageAsync(file, user.UserId);
 
-        user.ProfileImageUrl = imageUrl;
+        user.ProfileImageUrl = newImageUrl;
         user.UpdatedAt       = DateTime.UtcNow;
         await _db.SaveChangesAsync();
 
-        return Ok(new { profileImageUrl = imageUrl });
+        // Delete old blob only after new URL is safely persisted.
+        // Best-effort: a failed cleanup does not error the request.
+        if (!string.IsNullOrEmpty(previousImageUrl))
+        {
+            try
+            {
+                await _blobStorage.DeleteBlobAsync(previousImageUrl);
+            }
+            catch (Exception ex)
+            {
+                // Old blob cleanup failed — not critical, new image is already saved
+                Console.WriteLine($"Warning: failed to delete old profile image blob: {ex.Message}");
+            }
+        }
+
+        return Ok(new { profileImageUrl = newImageUrl });
     }
 
     // GET api/users — public

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using Backend.Data;
+using Backend.Services;
 using DotNetEnv;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
@@ -45,6 +46,12 @@ var connectionString = GetRequiredConfig(builder, "ConnectionStrings:DefaultConn
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));
+
+// ── Blob Storage ──────────────────────────────────────────────────────────────
+builder.Configuration["BlobStorage:ConnectionString"] =
+    Environment.GetEnvironmentVariable("AZURE_BLOB_CONNECTION_STRING") ?? "";
+
+builder.Services.AddSingleton<IBlobStorageService, BlobStorageService>();
 
 // ── Authentication — dual JWT Bearer (Google + Microsoft) ─────────────────────
 var googleClientId    = GetRequiredConfig(builder, "Authentication:Google:ClientId");

--- a/Backend/Program.cs
+++ b/Backend/Program.cs
@@ -48,8 +48,9 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(connectionString));
 
 // ── Blob Storage ──────────────────────────────────────────────────────────────
-builder.Configuration["BlobStorage:ConnectionString"] =
-    Environment.GetEnvironmentVariable("AZURE_BLOB_CONNECTION_STRING") ?? "";
+var blobConnectionString = Environment.GetEnvironmentVariable("AZURE_BLOB_CONNECTION_STRING");
+if (!string.IsNullOrWhiteSpace(blobConnectionString))
+    builder.Configuration["BlobStorage:ConnectionString"] = blobConnectionString;
 
 builder.Services.AddSingleton<IBlobStorageService, BlobStorageService>();
 

--- a/Backend/Services/BlobStorageService.cs
+++ b/Backend/Services/BlobStorageService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 
@@ -14,16 +15,26 @@ public class BlobStorageService : IBlobStorageService
 {
     private readonly BlobServiceClient _blobServiceClient;
     private readonly string _profileImagesContainer;
+    private readonly ConcurrentDictionary<string, bool> _ensuredContainers = new();
 
     public BlobStorageService(IConfiguration configuration)
     {
-        var connectionString = configuration["BlobStorage:ConnectionString"]
-            ?? throw new InvalidOperationException("BlobStorage:ConnectionString is not configured.");
+        var connectionString = configuration["BlobStorage:ConnectionString"];
+        if (string.IsNullOrWhiteSpace(connectionString))
+            throw new InvalidOperationException("BlobStorage:ConnectionString is not configured.");
 
         _profileImagesContainer = configuration["BlobStorage:ProfileImagesContainer"]
             ?? "profile-images";
 
         _blobServiceClient = new BlobServiceClient(connectionString);
+    }
+
+    private async Task EnsureContainerExistsAsync(BlobContainerClient containerClient)
+    {
+        if (_ensuredContainers.ContainsKey(containerClient.Name)) return;
+
+        await containerClient.CreateIfNotExistsAsync(PublicAccessType.Blob);
+        _ensuredContainers[containerClient.Name] = true;
     }
 
     public async Task<string> UploadProfileImageAsync(IFormFile file, int userId)
@@ -34,7 +45,7 @@ public class BlobStorageService : IBlobStorageService
     public async Task<string> UploadMediaAsync(IFormFile file, string containerName, int parentId)
     {
         var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
-        await containerClient.CreateIfNotExistsAsync(PublicAccessType.Blob);
+        await EnsureContainerExistsAsync(containerClient);
 
         var extension = Path.GetExtension(file.FileName).ToLowerInvariant();
         var blobName = $"{parentId}/{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}{extension}";
@@ -59,14 +70,23 @@ public class BlobStorageService : IBlobStorageService
     {
         if (string.IsNullOrWhiteSpace(blobUrl)) return;
 
-        var uri = new Uri(blobUrl);
+        // use TryCreate so a malformed URL can't crash the request pipeline
+        if (!Uri.TryCreate(blobUrl, UriKind.Absolute, out var uri)) return;
 
-        // Extract container and blob name from URL path: /container-name/blob-name
+        // validate host matches our storage account to prevent unintended deletions
+        var expectedHost = _blobServiceClient.Uri.Host;
+        if (!uri.Host.Equals(expectedHost, StringComparison.OrdinalIgnoreCase)) return;
+
+        // extract and validate against an allowlist of known containers
         var segments = uri.AbsolutePath.TrimStart('/').Split('/', 2);
         if (segments.Length < 2) return;
 
-        var containerName = segments[0]; // e.g. "profile-images"
-        var blobName = segments[1];      // e.g. "42/1711234567890.jpg"
+        var containerName = segments[0];
+        var blobName = segments[1];
+
+        // only allow deletion from known containers
+        var allowedContainers = new[] { _profileImagesContainer, "project-media", "event-media" };
+        if (!allowedContainers.Contains(containerName)) return;
 
         var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
         var blobClient = containerClient.GetBlobClient(blobName);

--- a/Backend/Services/BlobStorageService.cs
+++ b/Backend/Services/BlobStorageService.cs
@@ -1,0 +1,76 @@
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+
+namespace Backend.Services;
+
+public interface IBlobStorageService
+{
+    Task<string> UploadProfileImageAsync(IFormFile file, int userId);
+    Task<string> UploadMediaAsync(IFormFile file, string containerName, int parentId);
+    Task DeleteBlobAsync(string blobUrl);
+}
+
+public class BlobStorageService : IBlobStorageService
+{
+    private readonly BlobServiceClient _blobServiceClient;
+    private readonly string _profileImagesContainer;
+
+    public BlobStorageService(IConfiguration configuration)
+    {
+        var connectionString = configuration["BlobStorage:ConnectionString"]
+            ?? throw new InvalidOperationException("BlobStorage:ConnectionString is not configured.");
+
+        _profileImagesContainer = configuration["BlobStorage:ProfileImagesContainer"]
+            ?? "profile-images";
+
+        _blobServiceClient = new BlobServiceClient(connectionString);
+    }
+
+    public async Task<string> UploadProfileImageAsync(IFormFile file, int userId)
+    {
+        return await UploadMediaAsync(file, _profileImagesContainer, userId);
+    }
+
+    public async Task<string> UploadMediaAsync(IFormFile file, string containerName, int parentId)
+    {
+        var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
+        await containerClient.CreateIfNotExistsAsync(PublicAccessType.Blob);
+
+        var extension = Path.GetExtension(file.FileName).ToLowerInvariant();
+        var blobName = $"{parentId}/{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}{extension}";
+
+        var blobClient = containerClient.GetBlobClient(blobName);
+
+        var blobHttpHeaders = new BlobHttpHeaders
+        {
+            ContentType = file.ContentType
+        };
+
+        await using var stream = file.OpenReadStream();
+        await blobClient.UploadAsync(stream, new BlobUploadOptions
+        {
+            HttpHeaders = blobHttpHeaders
+        });
+
+        return blobClient.Uri.ToString();
+    }
+
+    public async Task DeleteBlobAsync(string blobUrl)
+    {
+        if (string.IsNullOrWhiteSpace(blobUrl)) return;
+
+        var uri = new Uri(blobUrl);
+
+        // Extract container and blob name from URL path: /container-name/blob-name
+        var segments = uri.AbsolutePath.TrimStart('/').Split('/', 2);
+        if (segments.Length < 2) return;
+
+        var containerName = segments[0]; // e.g. "profile-images"
+        var blobName = segments[1];      // e.g. "42/1711234567890.jpg"
+
+        var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
+        var blobClient = containerClient.GetBlobClient(blobName);
+
+        await blobClient.DeleteIfExistsAsync();
+    }
+}

--- a/Backend/appsettings.json
+++ b/Backend/appsettings.json
@@ -11,6 +11,12 @@
       "TenantId": ""
     }
   },
+  "BlobStorage": {
+    "ConnectionString": "",
+    "ProfileImagesContainer": "profile-images",
+    "ProjectMediaContainer": "project-media",
+    "EventMediaContainer": "event-media"
+  },
   "Cors": {
     "AllowedOrigins": []
   },


### PR DESCRIPTION
Integrate Azure Blob Storage support: add Azure.Storage.Blobs package, a new BlobStorageService with IBlobStorageService (UploadProfileImageAsync, UploadMediaAsync, DeleteBlobAsync), and container configuration in appsettings.json and .env.example. Register the service in Program.cs and wire the connection string from AZURE_BLOB_CONNECTION_STRING. Update UsersController to depend on IBlobStorageService and add POST api/users/me/profile-image (5 MB limit, MIME type checks) which deletes an existing blob, uploads the new image, and stores the returned URL on the user. Includes URL-based blob deletion logic and creates containers with public blob access.